### PR TITLE
Increase caching in SW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ ignore-notes.md
 stats.html
 /functions/\[\[path\]\].js
 will-notes.md
+.wrangler

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,11 +82,6 @@ const initialData = {
   chap: defaultChap,
   verseRouting: undefined,
 };
-// Would cache more aggressivley, but brigthcove videop playback urls are not static.  Cache for 1 hours at a time in browser (in case some) (in case someone caches close to the time that bc cdn changes urls), and then cache on cdn for 1 day at a time.
-Astro.response.headers.set(
-  "Cache-Control",
-  "public, max-age=3600, s-maxage=86400, must-revalidate"
-);
 
 let cfEnv: envPropsForPlayer = {
   accountId: "",

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -81,26 +81,7 @@ registerRoute(
     ],
   })
 );
-// cdn video segments
-registerRoute(
-  ({url}) => {
-    const vidSegmentFile = /akamaihd.+segment/;
-    const isSegmentFile = vidSegmentFile.test(url.href);
-    return isSegmentFile;
-  },
-  new CacheFirst({
-    cacheName: "dot-vid-segments",
-    plugins: [
-      new CacheableResponsePlugin({
-        statuses: [200, 304],
-      }),
-      new ExpirationPlugin({
-        maxEntries: 50000,
-        maxAgeSeconds: 60 * 60 * 24 * 90, // 180 days
-      }),
-    ],
-  })
-);
+
 // html navigations
 registerRoute(
   ({request}) => {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -81,7 +81,27 @@ registerRoute(
     ],
   })
 );
-
+// cdn video segments
+registerRoute(
+  ({url}) => {
+    const vidSegmentFile = /akamaihd.+segment/;
+    const isSegmentFile = vidSegmentFile.test(url.href);
+    return isSegmentFile;
+  },
+  new CacheFirst({
+    cacheName: "dot-vid-segments",
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [200, 304],
+      }),
+      new ExpirationPlugin({
+        maxEntries: 50000,
+        maxAgeSeconds: 60 * 60 * 24 * 90, // 180 days
+      }),
+    ],
+  })
+);
+// html navigations
 registerRoute(
   ({request}) => {
     if (request.mode == "navigate") {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,7 +3,7 @@ import {downloadZip} from "client-zip";
 import {SW_CACHE_NAME} from "./constants";
 import {cleanupOutdatedCaches, precacheAndRoute} from "workbox-precaching";
 import {registerRoute} from "workbox-routing";
-import {StaleWhileRevalidate} from "workbox-strategies";
+import {StaleWhileRevalidate, CacheFirst} from "workbox-strategies";
 import {CacheableResponsePlugin} from "workbox-cacheable-response";
 import {ExpirationPlugin} from "workbox-expiration";
 
@@ -19,22 +19,17 @@ cleanupOutdatedCaches();
 precacheAndRoute(self.__WB_MANIFEST);
 
 registerRoute(
-  ({url, sameOrigin, request}) => {
+  ({url}) => {
     const isForVidJs =
       url.href.includes("https://players.brightcove.net/6314154063001") ||
       url.href.includes(
         "https://players.brightcove.net/videojs-vtt.js/0.15.4/vtt.global.min.js"
       );
 
-    const alsoCache =
-      sameOrigin &&
-      (/\/icons\/.*\.png/.test(url.href) ||
-        /fonts\/.+\/.+.woff[2]?/.test(url.href) ||
-        request.destination == "image");
     if (isForVidJs) {
       console.log("vidjs file acknowledged from the service worker!");
     }
-    return isForVidJs || alsoCache;
+    return isForVidJs;
     // return false;
   },
   new StaleWhileRevalidate({
@@ -47,6 +42,45 @@ registerRoute(
   })
 );
 // static assets
+registerRoute(
+  ({url, sameOrigin, request}) => {
+    const isVidJsCss = url.href.includes("video-js.css");
+    const astroRegex = /\/_astro\/.+.((css)|(js))/gim;
+    const fontsRegex = /fonts\/.+\/.+.woff[2]?/;
+    const isAstroHashedContent = astroRegex.test(url.href);
+    const isFont = fontsRegex.test(url.href);
+    const isImage = sameOrigin && request.destination == "image";
+    return isVidJsCss || isAstroHashedContent || isFont || isImage;
+  },
+  new CacheFirst({
+    cacheName: "dot-static-assets",
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [200, 304],
+      }),
+    ],
+  })
+);
+// cdn  images
+registerRoute(
+  ({url}) => {
+    const vidPosterRegex = /akamaihd.net\/image/;
+    const isVidPoster = vidPosterRegex.test(url.href);
+    return isVidPoster;
+  },
+  new CacheFirst({
+    cacheName: "dot-cdn-assets",
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [200, 304],
+      }),
+      new ExpirationPlugin({
+        maxEntries: 1000,
+        maxAgeSeconds: 60 * 60 * 24 * 30, //30 days
+      }),
+    ],
+  })
+);
 
 registerRoute(
   ({request}) => {
@@ -184,3 +218,13 @@ self.addEventListener("fetch", async (event) => {
     return event.respondWith(handleFormRequest());
   }
 });
+
+/* 
+1,732,142,781
+1,370,627,409
+31557600
+https://bcbolt446c5271-a.akamaihd.net/image/v1/jit/6314154063001/52653555-8ec6-43b1-aa54-03ee1fea3e41/main/480x270/5s/match/image.jpeg?akamai_token=exp=1732142781~acl=/image/v1/jit/6314154063001/52653555-8ec6-43b1-aa54-03ee1fea3e41/main/480x270/5s/match/image.jpeg*~hmac=77547b62f7758466099649eaebc481e6c41f11265465c670be2de3cb3a3ab320
+
+
+https://bcbolt446c5271-a.akamaihd.net/image/v1/jit/6314154063001/52653555-8ec6-43b1-aa54-03ee1fea3e41/main/480x270/5s/match/image.jpeg?akamai_token=exp=1732142781~acl=/image/v1/jit/6314154063001/52653555-8ec6-43b1-aa54-03ee1fea3e41/main/480x270/5s/match/image.jpeg*~hmac=77547b62f7758466099649eaebc481e6c41f11265465c670be2de3cb3a3ab320
+*/


### PR DESCRIPTION
Now that Brightcove ttl tokens should last longer, we can increase caching in the service worker to enable a more performant load for repeat visitors. 